### PR TITLE
Fix the obviously broken `generate_access_token` method.

### DIFF
--- a/lib/docusign_esign/client/api_client.rb
+++ b/lib/docusign_esign/client/api_client.rb
@@ -570,14 +570,14 @@ module DocuSign_eSign
           :return_type => 'OAuth::OAuthToken',
           :oauth => true
       }
-      data, status_code, headers = self.call_api("POST", '/oauth/token', params)
-      abort(data.inspect)
 
+      token, status_code, headers = self.call_api("POST", '/oauth/token', params)
+
+      if status_code == 200
+        self.default_headers.store('Authorization', "#{token.token_type} #{token.access_token}")
+      end
     end
 
-    def set_access_token(token_obj)
-      self.default_headers['Authorization'] = token_obj.access_token
-    end
 
     # Helper method to add default header params
     # @param [String] header_name

--- a/lib/docusign_esign/client/api_client.rb
+++ b/lib/docusign_esign/client/api_client.rb
@@ -575,6 +575,8 @@ module DocuSign_eSign
 
       if status_code == 200
         self.default_headers.store('Authorization', "#{token.token_type} #{token.access_token}")
+
+        token
       end
     end
 


### PR DESCRIPTION
It's wildly unprofessional to have a broken official gem linked to your official developer docs. I saw the discussion here #37 that mentions deprecation, but all the docs continue to mention it including the README of this project.

